### PR TITLE
Implement initial RVQ training scaffold

### DIFF
--- a/signstream/configs/default.yaml
+++ b/signstream/configs/default.yaml
@@ -1,0 +1,27 @@
+# Default configuration for SignStream RVQ project
+# Paths
+csl_daily_root: /workspace/data/public_data/CSL_Daily
+
+model:
+  encoder_layer: 2
+  encoder_latent_dim: 256
+  latent_dim: 256
+  type_embed_dim: 16
+  rvq:
+    levels: 2
+    codebook_size: 512
+    ema_decay: 0.99
+    commitment_beta: 0.25
+    usage_reg: 1e-3
+
+train:
+  epochs: 1
+  batch_size: 2
+  lr: 3e-4
+  wd: 0.0
+  amp: false
+  seed: 42
+
+export:
+  enable_rle: true
+  rle_threshold: 0.02

--- a/signstream/data/collate.py
+++ b/signstream/data/collate.py
@@ -1,0 +1,22 @@
+"""Custom collate functions for DataLoader."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+
+
+def simple_collate(batch: List[Dict]) -> Dict:
+    """Stack tensors from the batch into a single dictionary.
+
+    The batch items are expected to be dictionaries produced by
+    ``CSLDailyDataset`` where every value except ``name`` is a tensor with the
+    same shape.
+    """
+    names = [item["name"] for item in batch]
+    result: Dict[str, torch.Tensor] = {"name": names}
+    keys = [k for k in batch[0].keys() if k != "name"]
+    for k in keys:
+        tensors = [item[k] for item in batch]
+        result[k] = torch.stack(tensors, dim=0)
+    return result

--- a/signstream/data/datasets.py
+++ b/signstream/data/datasets.py
@@ -1,0 +1,58 @@
+"""Dataset definitions for SignStream project."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+from torch.utils.data import Dataset
+
+from .transforms import build_default_transform
+
+
+class CSLDailyDataset(Dataset):
+    """Minimal dataset for the CSL-Daily pose data.
+
+    The dataset expects the directory structure described in
+    ``CSL-Daily_README.md``. Only the pose ``.npy`` files are required for
+    the minimal training pipeline.
+    """
+
+    def __init__(
+        self,
+        root: str,
+        split: str = "train",
+        transform: Optional[Callable] = None,
+        max_samples: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+        self.root = root
+        self.split = split
+        self.transform = transform or build_default_transform()
+
+        split_file = os.path.join(root, "split_files.json")
+        with open(split_file, "r", encoding="utf-8") as f:
+            split_info = json.load(f)
+        names: List[str] = split_info.get(split, [])
+
+        self.samples: List[Dict[str, str]] = []
+        for name in names:
+            npy_path = os.path.join(root, "frames_512x512", f"{name}.npy")
+            if os.path.exists(npy_path):
+                self.samples.append({"name": name, "npy": npy_path})
+            if max_samples is not None and len(self.samples) >= max_samples:
+                break
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        sample = self.samples[idx]
+        pose = np.load(sample["npy"])  # [T, 134, 3]
+        if self.transform is not None:
+            data = self.transform(pose)
+        else:
+            data = {"full_body": pose}
+        data["name"] = sample["name"]
+        return data

--- a/signstream/data/transforms.py
+++ b/signstream/data/transforms.py
@@ -1,0 +1,56 @@
+"""Data transformation utilities for CSL-Daily poses."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Callable
+import numpy as np
+import torch
+
+# Slices for different body parts (0-based indexing, 134 points total)
+BODY_SLICE = slice(1, 24)  # 1-23, torso (foot keys ignored)
+FACE_SLICE = slice(24, 92)
+LEFT_HAND_SLICE = slice(92, 113)
+RIGHT_HAND_SLICE = slice(113, 134)
+FULL_BODY_SLICE = slice(1, 134)
+
+
+def split_streams(pose: np.ndarray) -> Dict[str, np.ndarray]:
+    """Split a pose array into sub streams.
+
+    Args:
+        pose: numpy array of shape [T, 134, 3]
+
+    Returns:
+        dict mapping stream name to array of shape [T, J, 3]
+    """
+    return {
+        "face": pose[:, FACE_SLICE],
+        "left_hand": pose[:, LEFT_HAND_SLICE],
+        "right_hand": pose[:, RIGHT_HAND_SLICE],
+        "body": pose[:, BODY_SLICE],
+        "full_body": pose[:, FULL_BODY_SLICE],
+    }
+
+
+@dataclass
+class Compose:
+    """Compose several transforms together."""
+    transforms: Iterable[Callable]
+
+    def __call__(self, pose: np.ndarray) -> Dict[str, np.ndarray]:
+        result = pose
+        for t in self.transforms:
+            result = t(result)
+        return result
+
+
+class ToTensor:
+    """Convert numpy arrays in the sample dictionary to torch tensors."""
+
+    def __call__(self, sample: Dict[str, np.ndarray]) -> Dict[str, torch.Tensor]:
+        return {k: torch.from_numpy(v).float() for k, v in sample.items()}
+
+
+def build_default_transform() -> Compose:
+    """Return the default transformation pipeline."""
+    return Compose([split_streams, ToTensor()])

--- a/signstream/inference/export_tokens.py
+++ b/signstream/inference/export_tokens.py
@@ -1,0 +1,50 @@
+"""Export discrete tokens from a trained model."""
+from __future__ import annotations
+
+import argparse
+import json
+import yaml
+import torch
+
+from signstream.data.datasets import CSLDailyDataset
+from signstream.data.collate import simple_collate
+from signstream.models.rvq.rvq_model import RVQAutoEncoder
+from .rle import run_length_encode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export tokens")
+    parser.add_argument("--config", type=str, default="signstream/configs/default.yaml")
+    parser.add_argument("--checkpoint", type=str, required=True)
+    parser.add_argument("--out", type=str, default="tokens.jsonl")
+    parser.add_argument("--num-samples", type=int, default=5)
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    dataset = CSLDailyDataset(cfg["csl_daily_root"], split="val", max_samples=args.num_samples)
+    loader = torch.utils.data.DataLoader(dataset, batch_size=1, collate_fn=simple_collate)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = RVQAutoEncoder(133, cfg["model"]["latent_dim"], cfg["model"]["rvq"]).to(device)
+    state = torch.load(args.checkpoint, map_location="cpu")
+    model.load_state_dict(state["model"])
+    model.eval()
+
+    with open(args.out, "w", encoding="utf-8") as out_f:
+        for batch in loader:
+            name = batch["name"][0]
+            x = batch["full_body"].to(device)
+            with torch.no_grad():
+                out = model(x)
+            indices = [ind.squeeze(0).tolist() for ind in out["indices"]]
+            tokens = {
+                "video_name": name,
+                "tokens": indices,
+            }
+            out_f.write(json.dumps(tokens) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/signstream/inference/rle.py
+++ b/signstream/inference/rle.py
@@ -1,28 +1,26 @@
+"""Simple run-length encoding utilities."""
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Iterable, List, Tuple, TypeVar
+
+T = TypeVar("T")
 
 
-def run_length_encode(seq: List[Any]) -> List[Any]:
-    """Encode a sequence using simple run-length encoding.
-
-    The first element of a run is kept, and subsequent repetitions are
-    represented as ["NC", count].
-    """
-    if not seq:
+def run_length_encode(seq: Iterable[T]) -> List[Tuple[T, int]]:
+    """Run-length encode a sequence."""
+    iterator = iter(seq)
+    try:
+        prev = next(iterator)
+    except StopIteration:
         return []
-    result: List[Any] = [seq[0]]
-    prev = seq[0]
     count = 1
-    for item in seq[1:]:
+    result: List[Tuple[T, int]] = []
+    for item in iterator:
         if item == prev:
             count += 1
         else:
-            if count > 1:
-                result.append(["NC", count - 1])
-            result.append(item)
+            result.append((prev, count))
             prev = item
             count = 1
-    if count > 1:
-        result.append(["NC", count - 1])
+    result.append((prev, count))
     return result

--- a/signstream/inference/viz.py
+++ b/signstream/inference/viz.py
@@ -1,14 +1,9 @@
+"""Placeholder visualization helpers."""
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
-from typing import Dict, List
+from typing import List
 
 
-def plot_code_usage(tokens: Dict[str, List[List[int]]]) -> None:
-    """Simple bar plot of code usage for each stream."""
-    for stream, seq in tokens.items():
-        flat = [code for codes in seq for code in codes]
-        plt.figure()
-        plt.hist(flat, bins=50)
-        plt.title(stream)
-        plt.show()
+def print_tokens(tokens: List[int]) -> None:
+    """Print token ids for quick debugging."""
+    print("Tokens:", tokens)

--- a/signstream/io/dataloader_utils.py
+++ b/signstream/io/dataloader_utils.py
@@ -1,8 +1,14 @@
+"""DataLoader helper functions."""
 from __future__ import annotations
 
-from torch.utils.data import DataLoader, Dataset
-from typing import Callable, Optional
+import random
+from typing import Any
+
+import numpy as np
+import torch
 
 
-def create_dataloader(dataset: Dataset, batch_size: int, shuffle: bool = True, collate_fn: Optional[Callable] = None) -> DataLoader:
-    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, collate_fn=collate_fn)
+def worker_init_fn(worker_id: int) -> None:
+    seed = torch.initial_seed() % 2 ** 32
+    np.random.seed(seed + worker_id)
+    random.seed(seed + worker_id)

--- a/signstream/io/readme_parser.py
+++ b/signstream/io/readme_parser.py
@@ -1,10 +1,10 @@
+"""Utilities to read dataset README files."""
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Dict
 
 
-def read_dataset_readme(path: str | Path) -> str:
-    """Return contents of dataset README for logging purposes."""
+def read_text(path: str) -> str:
+    """Return the contents of a text file."""
     with open(path, "r", encoding="utf-8") as f:
         return f.read()

--- a/signstream/models/metrics/recon.py
+++ b/signstream/models/metrics/recon.py
@@ -1,0 +1,10 @@
+"""Reconstruction metrics."""
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def mse(recon: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Compute mean squared error."""
+    return F.mse_loss(recon, target)

--- a/signstream/models/rvq/decoder.py
+++ b/signstream/models/rvq/decoder.py
@@ -1,0 +1,23 @@
+"""Decoder symmetric to the pose encoder."""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class PoseDecoder(nn.Module):
+    def __init__(self, num_joints: int, latent_dim: int) -> None:
+        super().__init__()
+        out_dim = num_joints * 3
+        self.net = nn.Sequential(
+            nn.Linear(latent_dim, latent_dim),
+            nn.ReLU(),
+            nn.Linear(latent_dim, out_dim),
+        )
+        self.num_joints = num_joints
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:  # z: [B, T, D]
+        b, t, d = z.shape
+        z_flat = z.view(b * t, d)
+        out = self.net(z_flat)
+        return out.view(b, t, self.num_joints, 3)

--- a/signstream/models/rvq/encoder.py
+++ b/signstream/models/rvq/encoder.py
@@ -1,0 +1,24 @@
+"""Simple pose encoder."""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class PoseEncoder(nn.Module):
+    """Encode pose sequences into latent representations."""
+
+    def __init__(self, num_joints: int, latent_dim: int) -> None:
+        super().__init__()
+        in_dim = num_joints * 3
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, latent_dim),
+            nn.ReLU(),
+            nn.Linear(latent_dim, latent_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # x: [B, T, J, 3]
+        b, t, j, c = x.shape
+        x_flat = x.view(b * t, j * c)
+        out = self.net(x_flat)
+        return out.view(b, t, -1)

--- a/signstream/models/rvq/quantizer.py
+++ b/signstream/models/rvq/quantizer.py
@@ -1,0 +1,75 @@
+"""Residual vector quantiser with EMA updates."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class EMAQuantizer(nn.Module):
+    """A single level vector quantizer using EMA updates."""
+
+    def __init__(self, codebook_size: int, dim: int, decay: float = 0.99, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.codebook_size = codebook_size
+        self.dim = dim
+        self.decay = decay
+        self.eps = eps
+
+        embed = torch.randn(codebook_size, dim)
+        self.embedding = nn.Parameter(embed)
+        self.register_buffer("ema_cluster_size", torch.zeros(codebook_size))
+        self.register_buffer("ema_embed", torch.zeros(codebook_size, dim))
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        flat = x.reshape(-1, self.dim)
+        distances = (
+            flat.pow(2).sum(1, keepdim=True)
+            - 2 * flat @ self.embedding.t()
+            + self.embedding.pow(2).sum(1)
+        )
+        indices = torch.argmin(distances, dim=1)
+        quantized = F.embedding(indices, self.embedding).view_as(x)
+
+        if self.training:
+            one_hot = F.one_hot(indices, self.codebook_size).type_as(flat)
+            self.ema_cluster_size.mul_(self.decay).add_(one_hot.sum(0), alpha=1 - self.decay)
+            self.ema_embed.mul_(self.decay).add_(one_hot.t() @ flat, alpha=1 - self.decay)
+            n = self.ema_cluster_size.sum()
+            cluster_size = (
+                (self.ema_cluster_size + self.eps)
+                / (n + self.codebook_size * self.eps)
+                * n
+            )
+            embed_normalised = self.ema_embed / cluster_size.unsqueeze(1)
+            self.embedding.data.copy_(embed_normalised)
+
+        loss = F.mse_loss(quantized.detach(), x) + F.mse_loss(quantized, x.detach())
+        quantized = x + (quantized - x).detach()
+        return quantized, indices.view(x.shape[:-1]), loss
+
+
+class ResidualVectorQuantizer(nn.Module):
+    """Multi-level residual vector quantizer."""
+
+    def __init__(self, levels: int, codebook_size: int, dim: int, decay: float = 0.99) -> None:
+        super().__init__()
+        self.levels = nn.ModuleList(
+            [EMAQuantizer(codebook_size, dim, decay) for _ in range(levels)]
+        )
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor], torch.Tensor]:
+        residual = x
+        quantized_outputs = []
+        indices_list: List[torch.Tensor] = []
+        loss = torch.tensor(0.0, device=x.device)
+        for q in self.levels:
+            q_out, q_ind, q_loss = q(residual)
+            quantized_outputs.append(q_out)
+            indices_list.append(q_ind)
+            residual = residual - q_out
+            loss = loss + q_loss
+        quantized = torch.stack(quantized_outputs, dim=0).sum(0)
+        return quantized, indices_list, loss

--- a/signstream/models/rvq/rvq_model.py
+++ b/signstream/models/rvq/rvq_model.py
@@ -1,0 +1,41 @@
+"""End-to-end RVQ autoencoder model."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .encoder import PoseEncoder
+from .decoder import PoseDecoder
+from .quantizer import ResidualVectorQuantizer
+
+
+class RVQAutoEncoder(nn.Module):
+    """Shared encoder/decoder with a residual vector quantiser."""
+
+    def __init__(self, num_joints: int, latent_dim: int, rvq_cfg: Dict) -> None:
+        super().__init__()
+        self.encoder = PoseEncoder(num_joints, latent_dim)
+        self.quantizer = ResidualVectorQuantizer(
+            rvq_cfg.get("levels", 2),
+            rvq_cfg.get("codebook_size", 512),
+            latent_dim,
+            rvq_cfg.get("ema_decay", 0.99),
+        )
+        self.decoder = PoseDecoder(num_joints, latent_dim)
+
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+        latent = self.encoder(x)
+        quantized, indices, q_loss = self.quantizer(latent)
+        recon = self.decoder(quantized)
+        recon_loss = F.mse_loss(recon, x)
+        total_loss = recon_loss + q_loss
+        return {
+            "recon": recon,
+            "indices": indices,
+            "loss": total_loss,
+            "recon_loss": recon_loss,
+            "q_loss": q_loss,
+        }

--- a/signstream/tests/conftest.py
+++ b/signstream/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path so that `import signstream` works
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/signstream/tests/test_dataset.py
+++ b/signstream/tests/test_dataset.py
@@ -1,0 +1,26 @@
+import json
+import numpy as np
+import tempfile
+from pathlib import Path
+
+from signstream.data.datasets import CSLDailyDataset
+
+
+def create_dummy_dataset(tmpdir: Path):
+    root = tmpdir
+    (root / "frames_512x512").mkdir()
+    pose = np.zeros((2, 134, 3), dtype=np.float32)
+    np.save(root / "frames_512x512" / "sample.npy", pose)
+    with open(root / "split_files.json", "w") as f:
+        json.dump({"train": ["sample"]}, f)
+    return root
+
+
+def test_dataset_loading():
+    with tempfile.TemporaryDirectory() as d:
+        root = create_dummy_dataset(Path(d))
+        ds = CSLDailyDataset(str(root), split="train")
+        assert len(ds) == 1
+        item = ds[0]
+        assert "full_body" in item
+        assert item["full_body"].shape == (2, 133, 3)

--- a/signstream/tests/test_export.py
+++ b/signstream/tests/test_export.py
@@ -1,0 +1,6 @@
+from signstream.inference.rle import run_length_encode
+
+
+def test_rle():
+    seq = [1, 1, 1, 2, 2, 3]
+    assert run_length_encode(seq) == [(1, 3), (2, 2), (3, 1)]

--- a/signstream/tests/test_quantizer.py
+++ b/signstream/tests/test_quantizer.py
@@ -1,0 +1,12 @@
+import torch
+from signstream.models.rvq.quantizer import ResidualVectorQuantizer
+
+
+def test_rvq_shapes():
+    rvq = ResidualVectorQuantizer(levels=2, codebook_size=4, dim=3)
+    x = torch.randn(2, 5, 3)
+    q, indices, loss = rvq(x)
+    assert q.shape == x.shape
+    assert len(indices) == 2
+    assert indices[0].shape == x.shape[:-1]
+    assert loss.requires_grad

--- a/signstream/training/loop_rvq.py
+++ b/signstream/training/loop_rvq.py
@@ -1,0 +1,30 @@
+"""Training loop for the RVQ autoencoder."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+from .utils_tb import TensorBoardLogger
+
+
+def train_one_epoch(
+    model: torch.nn.Module,
+    dataloader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    epoch: int = 0,
+    logger: Optional[TensorBoardLogger] = None,
+) -> None:
+    model.train()
+    for step, batch in enumerate(dataloader):
+        x = batch["full_body"].to(device)
+        out = model(x)
+        loss = out["loss"]
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if logger is not None:
+            global_step = epoch * len(dataloader) + step
+            logger.log(global_step, loss=loss.item(), recon=out["recon_loss"].item(), q=out["q_loss"].item())

--- a/signstream/training/optim.py
+++ b/signstream/training/optim.py
@@ -1,11 +1,11 @@
+"""Optimizer utilities."""
 from __future__ import annotations
 
+from typing import Iterable
+
 import torch
+from torch.optim import AdamW
 
 
-def create_optimizer(
-    model: torch.nn.Module, lr: float | str, wd: float | str = 0.0
-) -> torch.optim.Optimizer:
-    lr_f = float(lr)
-    wd_f = float(wd)
-    return torch.optim.AdamW(model.parameters(), lr=lr_f, weight_decay=wd_f)
+def build_optimizer(params: Iterable[torch.nn.Parameter], lr: float, weight_decay: float = 0.0) -> AdamW:
+    return AdamW(list(params), lr=lr, weight_decay=weight_decay)

--- a/signstream/training/seed.py
+++ b/signstream/training/seed.py
@@ -1,6 +1,8 @@
+"""Utility to set random seeds for reproducibility."""
 from __future__ import annotations
 
 import random
+
 import numpy as np
 import torch
 

--- a/signstream/training/train_rvq.py
+++ b/signstream/training/train_rvq.py
@@ -1,0 +1,50 @@
+"""Entry point for training the RVQ autoencoder."""
+from __future__ import annotations
+
+import argparse
+import yaml
+import torch
+from torch.utils.data import DataLoader
+
+from signstream.data.datasets import CSLDailyDataset
+from signstream.data.collate import simple_collate
+from signstream.models.rvq.rvq_model import RVQAutoEncoder
+from .seed import set_seed
+from .optim import build_optimizer
+from .loop_rvq import train_one_epoch
+from .utils_tb import TensorBoardLogger
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train RVQ autoencoder")
+    parser.add_argument("--config", type=str, default="signstream/configs/default.yaml")
+    args = parser.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    train_cfg = cfg["train"]
+    set_seed(train_cfg.get("seed", 42))
+
+    dataset = CSLDailyDataset(cfg["csl_daily_root"], split="train", max_samples=train_cfg.get("max_samples", 10))
+    dataloader = DataLoader(
+        dataset,
+        batch_size=train_cfg["batch_size"],
+        shuffle=True,
+        collate_fn=simple_collate,
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = RVQAutoEncoder(133, cfg["model"]["latent_dim"], cfg["model"]["rvq"]).to(device)
+    optimizer = build_optimizer(model.parameters(), lr=train_cfg["lr"], weight_decay=train_cfg.get("wd", 0.0))
+    logger = TensorBoardLogger("runs")
+
+    for epoch in range(train_cfg["epochs"]):
+        train_one_epoch(model, dataloader, optimizer, device, epoch, logger)
+
+    logger.close()
+    torch.save({"model": model.state_dict()}, "rvq_model.pt")
+
+
+if __name__ == "__main__":
+    main()

--- a/signstream/training/utils_tb.py
+++ b/signstream/training/utils_tb.py
@@ -1,19 +1,18 @@
+"""TensorBoard logging utilities."""
 from __future__ import annotations
 
-try:
-    from torch.utils.tensorboard import SummaryWriter
-except Exception:  # pragma: no cover
-    SummaryWriter = None  # type: ignore
+from typing import Any
+
+from torch.utils.tensorboard import SummaryWriter
 
 
-class TBLogger:
-    def __init__(self, log_dir: str | None = None):
-        self.writer = SummaryWriter(log_dir) if SummaryWriter is not None else None
+class TensorBoardLogger:
+    def __init__(self, log_dir: str) -> None:
+        self.writer = SummaryWriter(log_dir)
 
-    def log_scalar(self, name: str, value: float, step: int) -> None:
-        if self.writer is not None:
-            self.writer.add_scalar(name, value, step)
+    def log(self, step: int, **metrics: Any) -> None:
+        for k, v in metrics.items():
+            self.writer.add_scalar(k, v, step)
 
-    def flush(self) -> None:
-        if self.writer is not None:
-            self.writer.flush()
+    def close(self) -> None:
+        self.writer.close()


### PR DESCRIPTION
## Summary
- add CSL-Daily dataset loader and transforms for splitting body part streams
- implement residual vector quantiser, encoder/decoder, and training utilities
- provide run-length encoding and token export helpers with basic unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94ff4a6e0832c9b6c68f5781af066